### PR TITLE
[FEAT] 배송 상태 변경 기능 구현

### DIFF
--- a/src/main/java/org/example/springplusteam/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/springplusteam/common/exception/ErrorCode.java
@@ -10,7 +10,9 @@ public enum ErrorCode {
     TOKEN_NOT_FOUND(401, "토큰 정보를 찾을 수 없습니다."),
     INVALID_TOKEN_ERROR(403, "토큰 정보가 잘못되었습니다."),
     EXISTS_EMAIL(400, "존재하는 이메일 입니다."),
-    PRODUCT_NOT_FOUND(404, "상품을 찾을 수 없습니다.");
+    PRODUCT_NOT_FOUND(404, "상품을 찾을 수 없습니다."),
+    ORDER_NOT_FOUND(404, "해당 주문을 찾을 수 없습니다."),
+    ORDER_BAD_REQUEST(400, "잘못된 주문 상태 변경 요청입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/org/example/springplusteam/controller/OrderController.java
+++ b/src/main/java/org/example/springplusteam/controller/OrderController.java
@@ -2,6 +2,7 @@ package org.example.springplusteam.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.springplusteam.common.security.AuthUser;
+import org.example.springplusteam.dto.order.req.OrderStatusReqDto;
 import org.example.springplusteam.dto.order.resp.OrderCreateRespDto;
 import org.example.springplusteam.dto.order.resp.OrderSearchRespDto;
 import org.example.springplusteam.dto.order.resp.OrderStatusRespDto;
@@ -45,14 +46,14 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.OK).body(respDtos);
     }
 
-    // 주문 상태 변경 메서드
     @PutMapping("/api/v1/orders/{orderId}/status")
     public ResponseEntity<OrderStatusRespDto> changeOrder(
             @AuthenticationPrincipal AuthUser user,
-            @PathVariable Long orderId
+            @PathVariable Long orderId,
+            @RequestBody OrderStatusReqDto reqDto
     ) {
         Long userId = user.getId();
-        OrderStatusRespDto respDto = orderService.changeOrder(userId, orderId);
+        OrderStatusRespDto respDto = orderService.changeOrder(userId, orderId,reqDto);
         return ResponseEntity.status(HttpStatus.OK).body(respDto);
     }
 }

--- a/src/main/java/org/example/springplusteam/controller/OrderController.java
+++ b/src/main/java/org/example/springplusteam/controller/OrderController.java
@@ -2,8 +2,9 @@ package org.example.springplusteam.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.springplusteam.common.security.AuthUser;
-import org.example.springplusteam.dto.order.OrderCreateRespDto;
+import org.example.springplusteam.dto.order.resp.OrderCreateRespDto;
 import org.example.springplusteam.dto.order.resp.OrderSearchRespDto;
+import org.example.springplusteam.dto.order.resp.OrderStatusRespDto;
 import org.example.springplusteam.service.OrderService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -36,11 +37,22 @@ public class OrderController {
             @RequestParam(defaultValue = "modifiedAt") String sortBy,
             @RequestParam(defaultValue = "desc") String direction
 
-    ){
+    ) {
         Long userId = user.getId();
         Sort sort = Sort.by(Sort.Direction.fromString(direction), sortBy);
         Pageable pageable = PageRequest.of(page, limit, sort);
         Page<OrderSearchRespDto> respDtos = orderService.getOrders(userId, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(respDtos);
+    }
+
+    // 주문 상태 변경 메서드
+    @PutMapping("/api/v1/orders/{orderId}/status")
+    public ResponseEntity<OrderStatusRespDto> changeOrder(
+            @AuthenticationPrincipal AuthUser user,
+            @PathVariable Long orderId
+    ) {
+        Long userId = user.getId();
+        OrderStatusRespDto respDto = orderService.changeOrder(userId, orderId);
+        return ResponseEntity.status(HttpStatus.OK).body(respDto);
     }
 }

--- a/src/main/java/org/example/springplusteam/domain/order/Order.java
+++ b/src/main/java/org/example/springplusteam/domain/order/Order.java
@@ -8,23 +8,23 @@ import org.example.springplusteam.common.BaseEntity;
 import org.example.springplusteam.domain.product.Product;
 import org.example.springplusteam.domain.user.User;
 
-    @Entity
-    @Getter
-    @Table(name = "orders")
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public class Order extends BaseEntity {
+@Entity
+@Getter
+@Table(name = "orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
 
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-        @ManyToOne(fetch = FetchType.LAZY)
-        @JoinColumn(name = "user_id")
-        private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-        @ManyToOne(fetch = FetchType.LAZY)
-        @JoinColumn(name = "product_id")
-        private Product product;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
 
     @Enumerated(EnumType.STRING)
     private DeliveryStatus deliveryStatus;

--- a/src/main/java/org/example/springplusteam/domain/order/Order.java
+++ b/src/main/java/org/example/springplusteam/domain/order/Order.java
@@ -34,4 +34,8 @@ public class Order extends BaseEntity {
         this.product = product;
         this.deliveryStatus = DeliveryStatus.READY;
     }
+
+    public void update(DeliveryStatus status) {
+        this.deliveryStatus = status;
+    }
 }

--- a/src/main/java/org/example/springplusteam/dto/order/req/OrderStatusReqDto.java
+++ b/src/main/java/org/example/springplusteam/dto/order/req/OrderStatusReqDto.java
@@ -1,0 +1,9 @@
+package org.example.springplusteam.dto.order.req;
+
+import lombok.Getter;
+import org.example.springplusteam.domain.order.DeliveryStatus;
+
+@Getter
+public class OrderStatusReqDto {
+    private DeliveryStatus status;
+}

--- a/src/main/java/org/example/springplusteam/dto/order/resp/OrderCreateRespDto.java
+++ b/src/main/java/org/example/springplusteam/dto/order/resp/OrderCreateRespDto.java
@@ -1,4 +1,4 @@
-package org.example.springplusteam.dto.order;
+package org.example.springplusteam.dto.order.resp;
 
 import lombok.Getter;
 import org.example.springplusteam.domain.order.DeliveryStatus;
@@ -12,7 +12,6 @@ public class OrderCreateRespDto {
     private int price;
     private DeliveryStatus deliveryStatus;
     private LocalDateTime createdAt;
-
 
     public OrderCreateRespDto(Long id, String productName,
                               int price,

--- a/src/main/java/org/example/springplusteam/dto/order/resp/OrderCreateRespDto.java
+++ b/src/main/java/org/example/springplusteam/dto/order/resp/OrderCreateRespDto.java
@@ -1,27 +1,16 @@
 package org.example.springplusteam.dto.order.resp;
 
+import lombok.Builder;
 import lombok.Getter;
 import org.example.springplusteam.domain.order.DeliveryStatus;
 
 import java.time.LocalDateTime;
-
+@Builder
 @Getter
 public class OrderCreateRespDto {
-    private Long id;
+    private Long orderId;
     private String productName;
     private int price;
     private DeliveryStatus deliveryStatus;
     private LocalDateTime createdAt;
-
-    public OrderCreateRespDto(Long id, String productName,
-                              int price,
-                              DeliveryStatus deliveryStatus,
-                              LocalDateTime createdAt
-                              ) {
-        this.id = id;
-        this.productName = productName;
-        this.price = price;
-        this.deliveryStatus = deliveryStatus;
-        this.createdAt = createdAt;
-    }
 }

--- a/src/main/java/org/example/springplusteam/dto/order/resp/OrderStatusRespDto.java
+++ b/src/main/java/org/example/springplusteam/dto/order/resp/OrderStatusRespDto.java
@@ -1,0 +1,17 @@
+package org.example.springplusteam.dto.order.resp;
+
+import lombok.Getter;
+import org.example.springplusteam.domain.order.DeliveryStatus;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+public class OrderStatusRespDto {
+    private Long orderId;
+    private String name;
+    private int price;
+    private DeliveryStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/org/example/springplusteam/dto/order/resp/OrderStatusRespDto.java
+++ b/src/main/java/org/example/springplusteam/dto/order/resp/OrderStatusRespDto.java
@@ -1,11 +1,12 @@
 package org.example.springplusteam.dto.order.resp;
 
+import lombok.Builder;
 import lombok.Getter;
 import org.example.springplusteam.domain.order.DeliveryStatus;
 
 import java.time.LocalDateTime;
 
-
+@Builder
 @Getter
 public class OrderStatusRespDto {
     private Long orderId;

--- a/src/main/java/org/example/springplusteam/dto/order/resp/OrderStatusRespDto.java
+++ b/src/main/java/org/example/springplusteam/dto/order/resp/OrderStatusRespDto.java
@@ -1,18 +1,17 @@
-package org.example.springplusteam.dto.order.resp;
+    package org.example.springplusteam.dto.order.resp;
 
-import lombok.Builder;
-import lombok.Getter;
-import org.example.springplusteam.domain.order.DeliveryStatus;
+    import lombok.Builder;
+    import lombok.Getter;
+    import org.example.springplusteam.domain.order.DeliveryStatus;
 
-import java.time.LocalDateTime;
-
-@Builder
-@Getter
-public class OrderStatusRespDto {
-    private Long orderId;
-    private String name;
-    private int price;
-    private DeliveryStatus status;
-    private LocalDateTime createdAt;
-    private LocalDateTime modifiedAt;
-}
+    import java.time.LocalDateTime;
+    @Builder
+    @Getter
+    public class OrderStatusRespDto {
+        private Long orderId;
+        private String name;
+        private int price;
+        private DeliveryStatus status;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+    }

--- a/src/main/java/org/example/springplusteam/service/OrderService.java
+++ b/src/main/java/org/example/springplusteam/service/OrderService.java
@@ -3,6 +3,7 @@ package org.example.springplusteam.service;
 import lombok.RequiredArgsConstructor;
 import org.example.springplusteam.common.exception.CustomApiException;
 import org.example.springplusteam.common.exception.ErrorCode;
+import org.example.springplusteam.domain.order.DeliveryStatus;
 import org.example.springplusteam.domain.order.Order;
 import org.example.springplusteam.domain.order.OrderRepository;
 import org.example.springplusteam.domain.order.OrderRepositoryCustomImpl;
@@ -10,14 +11,16 @@ import org.example.springplusteam.domain.product.Product;
 import org.example.springplusteam.domain.product.ProductRepository;
 import org.example.springplusteam.domain.user.User;
 import org.example.springplusteam.domain.user.UserRepository;
-import org.example.springplusteam.dto.order.OrderCreateRespDto;
+import org.example.springplusteam.dto.order.req.OrderStatusReqDto;
+import org.example.springplusteam.dto.order.resp.OrderCreateRespDto;
 import org.example.springplusteam.dto.order.resp.OrderSearchRespDto;
+import org.example.springplusteam.dto.order.resp.OrderStatusRespDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.example.springplusteam.common.exception.ErrorCode.USER_NOT_FOUND;
+import static org.example.springplusteam.common.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -56,6 +59,30 @@ public class OrderService {
             Pageable pageable
     ) {
         return orderRepositoryCustomImpl.searchOrdersByUser(userId, pageable);
+    }
+
+    @Transactional
+    public OrderStatusRespDto changeOrder(Long userId, Long orderId, OrderStatusReqDto reqDto) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new CustomApiException(ORDER_NOT_FOUND));
+
+        if (order.getDeliveryStatus().equals(DeliveryStatus.COMPLETED)) {
+            throw new CustomApiException(ORDER_BAD_REQUEST);
+        }
+
+        order.update(reqDto.getStatus());
+
+        orderRepository.saveAndFlush(order);
+        OrderStatusRespDto respDto = OrderStatusRespDto.builder()
+                .orderId(orderId)
+                .name(order.getProduct().getName())
+                .price(order.getProduct().getPrice())
+                .status(order.getDeliveryStatus())
+                .createdAt(order.getCreatedAt())
+                .modifiedAt(order.getModifiedAt())
+                .build();
+
+        return respDto;
     }
 }
 

--- a/src/main/java/org/example/springplusteam/service/OrderService.java
+++ b/src/main/java/org/example/springplusteam/service/OrderService.java
@@ -42,13 +42,13 @@ public class OrderService {
 
         orderRepository.save(order);
 
-        OrderCreateRespDto respDto = new OrderCreateRespDto(
-                order.getId(),
-                order.getProduct().getName(),
-                order.getProduct().getPrice(),
-                order.getDeliveryStatus(),
-                order.getCreatedAt()
-        );
+        OrderCreateRespDto respDto = OrderCreateRespDto.builder()
+                .orderId(order.getId())
+                .productName(order.getProduct().getName())
+                .price(order.getProduct().getPrice())
+                .deliveryStatus(order.getDeliveryStatus())
+                .createdAt(order.getCreatedAt())
+                .build();
 
         return respDto;
     }


### PR DESCRIPTION
***배송 상태 변경 RequestBody***

📌` PUT /api/v1/orders/{orderId}/status` 
* 해당 주문가 존재하지 않는 경우 예외가 발생합니다.
* 해당 주문 상태가  "COMPLETE"에서 API 호출할 경우 예외가 발생합니다.

```json
{
  "status": "SHIPPING"
}
```

***배송 상태 변경 ReseponseBody***
```json
{ 
  "id":  1,
  "productName" : "서울 오페라 공연",
  "price" : 200000,
  "status" : "SHIPPING",
  "createdAt" : "2024-10-21 10:00:00",
  "modifiedAt" : "2024-10-22 11:34:25"
}
```
* 주문 상태 : "READY" /  "SHIPPING"  / "COMPLETED"
