### PR TITLE
[FEAT] 티켓 생성 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/generated/org/example/springplusteam/domain/ticket/QTicket.java
+++ b/src/main/generated/org/example/springplusteam/domain/ticket/QTicket.java
@@ -1,0 +1,45 @@
+package org.example.springplusteam.domain.ticket;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTicket is a Querydsl query type for Ticket
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTicket extends EntityPathBase<Ticket> {
+
+    private static final long serialVersionUID = -1431715392L;
+
+    public static final QTicket ticket = new QTicket("ticket");
+
+    public final NumberPath<Long> Id = createNumber("Id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public final NumberPath<Integer> price = createNumber("price", Integer.class);
+
+    public final NumberPath<Integer> quantity = createNumber("quantity", Integer.class);
+
+    public final NumberPath<Integer> useQuantity = createNumber("useQuantity", Integer.class);
+
+    public QTicket(String variable) {
+        super(Ticket.class, forVariable(variable));
+    }
+
+    public QTicket(Path<? extends Ticket> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTicket(PathMetadata metadata) {
+        super(Ticket.class, metadata);
+    }
+
+}
+

--- a/src/main/java/org/example/springplusteam/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/springplusteam/common/exception/ErrorCode.java
@@ -12,7 +12,10 @@ public enum ErrorCode {
     EXISTS_EMAIL(400, "존재하는 이메일 입니다."),
     PRODUCT_NOT_FOUND(404, "상품을 찾을 수 없습니다."),
     ORDER_NOT_FOUND(404, "해당 주문을 찾을 수 없습니다."),
-    ORDER_BAD_REQUEST(400, "잘못된 주문 상태 변경 요청입니다.");
+    ORDER_BAD_REQUEST(400, "잘못된 주문 상태 변경 요청입니다."),
+    TICKET_NOT_FOUND(404, "티켓을 찾을 수 없습니다."),
+    ;
+
 
     private final int status;
     private final String message;

--- a/src/main/java/org/example/springplusteam/common/security/SecurityConfig.java
+++ b/src/main/java/org/example/springplusteam/common/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.example.springplusteam.common.security.filter.CustomAuthenticationFil
 import org.example.springplusteam.common.security.filter.CustomAuthorizationFilter;
 import org.example.springplusteam.common.security.filter.GlobalExceptionHandlerFilter;
 import org.example.springplusteam.common.security.jwt.JwtUtil;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -44,7 +46,7 @@ public class SecurityConfig {
                         .dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR).permitAll()
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers("/error").permitAll()
-                        .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers(PathRequest.toH2Console()).permitAll()
                         .anyRequest().authenticated())
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                 .csrf(AbstractHttpConfigurer::disable)
@@ -61,6 +63,8 @@ public class SecurityConfig {
         return http.build();
     }
 
+
+
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
@@ -71,5 +75,12 @@ public class SecurityConfig {
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
         provider.setUserDetailsService(authUserService);
         return provider;
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "spring.h2.console.enabled", havingValue = "true")
+    public WebSecurityCustomizer configureH2ConsoleEnable() {
+        return web -> web.ignoring()
+                .requestMatchers(PathRequest.toH2Console());
     }
 }

--- a/src/main/java/org/example/springplusteam/config/RedisConfig.java
+++ b/src/main/java/org/example/springplusteam/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package org.example.springplusteam.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/org/example/springplusteam/controller/TicketController.java
+++ b/src/main/java/org/example/springplusteam/controller/TicketController.java
@@ -1,0 +1,24 @@
+package org.example.springplusteam.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.springplusteam.dto.ticket.req.TicketCreateReqDto;
+import org.example.springplusteam.dto.ticket.resp.TicketCreateRespDto;
+import org.example.springplusteam.service.TicketService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TicketController {
+
+    private final TicketService ticketService;
+
+
+    @PostMapping("/api/v1/tickets")
+    public ResponseEntity<TicketCreateRespDto> saveTicket(@RequestBody TicketCreateReqDto dto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(ticketService.addTicket(dto));
+    }
+}

--- a/src/main/java/org/example/springplusteam/domain/ticket/Ticket.java
+++ b/src/main/java/org/example/springplusteam/domain/ticket/Ticket.java
@@ -1,0 +1,31 @@
+package org.example.springplusteam.domain.ticket;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "tickets")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Ticket {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+    private String name;
+    private int price;
+    private int quantity;
+    private int useQuantity;
+
+    @Builder
+    public Ticket(Long id, String name, int price, int quantity, int useQuantity) {
+        Id = id;
+        this.name = name;
+        this.price = price;
+        this.quantity = quantity;
+        this.useQuantity = useQuantity;
+    }
+}

--- a/src/main/java/org/example/springplusteam/domain/ticket/TicketRepository.java
+++ b/src/main/java/org/example/springplusteam/domain/ticket/TicketRepository.java
@@ -1,0 +1,6 @@
+package org.example.springplusteam.domain.ticket;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+}

--- a/src/main/java/org/example/springplusteam/dto/ticket/req/TicketCreateReqDto.java
+++ b/src/main/java/org/example/springplusteam/dto/ticket/req/TicketCreateReqDto.java
@@ -1,0 +1,22 @@
+package org.example.springplusteam.dto.ticket.req;
+
+
+import lombok.Getter;
+import org.example.springplusteam.domain.ticket.Ticket;
+
+@Getter
+public class TicketCreateReqDto {
+    private String name;
+    private int price;
+    private int quantity;
+    private int useQuantity;
+
+    public static Ticket from(TicketCreateReqDto dto) {
+        return Ticket.builder()
+                .name(dto.getName())
+                .price(dto.getPrice())
+                .quantity(dto.getQuantity())
+                .useQuantity(dto.getUseQuantity())
+                .build();
+    }
+}

--- a/src/main/java/org/example/springplusteam/dto/ticket/resp/TicketCreateRespDto.java
+++ b/src/main/java/org/example/springplusteam/dto/ticket/resp/TicketCreateRespDto.java
@@ -1,0 +1,21 @@
+package org.example.springplusteam.dto.ticket.resp;
+
+import lombok.Getter;
+import org.example.springplusteam.domain.ticket.Ticket;
+
+@Getter
+public class TicketCreateRespDto {
+    private Long id;
+    private String name;
+    private int price;
+    private int quantity;
+    private int useQuantity;
+
+    public TicketCreateRespDto(Ticket ticket) {
+        this.id = ticket.getId();
+        this.name = ticket.getName();
+        this.price = ticket.getPrice();
+        this.quantity = ticket.getQuantity();
+        this.useQuantity = ticket.getUseQuantity();
+    }
+}

--- a/src/main/java/org/example/springplusteam/service/TicketService.java
+++ b/src/main/java/org/example/springplusteam/service/TicketService.java
@@ -1,0 +1,36 @@
+package org.example.springplusteam.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.example.springplusteam.common.exception.CustomApiException;
+import org.example.springplusteam.common.exception.ErrorCode;
+import org.example.springplusteam.domain.ticket.Ticket;
+import org.example.springplusteam.domain.ticket.TicketRepository;
+import org.example.springplusteam.dto.ticket.req.TicketCreateReqDto;
+import org.example.springplusteam.dto.ticket.resp.TicketCreateRespDto;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TicketService {
+
+    private final TicketRepository ticketRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public TicketCreateRespDto addTicket(TicketCreateReqDto dto) {
+        Ticket savedTicket = ticketRepository.save(TicketCreateReqDto.from(dto));
+        initializeTicket(savedTicket.getId());
+        return new TicketCreateRespDto(savedTicket);
+    }
+
+    private void initializeTicket(Long ticketId) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new CustomApiException(ErrorCode.TICKET_NOT_FOUND));
+
+        String key = "ticket:seat:" + ticketId;
+
+        redisTemplate.delete(key);
+        redisTemplate.opsForValue().set(key + ":seatCount", String.valueOf(ticket.getQuantity()));
+    }
+}


### PR DESCRIPTION
### 티켓 생성 기능 구현 

- 레디스 의존성 추가
- 레디스 설정 추가 
- 티켓 생성 시 redist 에 값을 동시에 세팅

ps. h2 접근 안되는 현상 해결 

📌 `POST /api/v1/tickets`

***RequestBody***

```json
{
   "name": "Spring" , 
   "price": 1000, 
   "quantity": 100, 
   "useQuantity": 0 
}
```

***ResponseBody*** 
```json 
{
   "id": 1,
   "name": "Spring",
   "price": 1000, 
   "quantity": 100, 
   "useQuantity": 0
}
```