### PR TITLE
[FEAET] 티켓 발급 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/generated/org/example/springplusteam/domain/myTicket/QMyTicket.java
+++ b/src/main/generated/org/example/springplusteam/domain/myTicket/QMyTicket.java
@@ -1,0 +1,62 @@
+package org.example.springplusteam.domain.myTicket;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMyTicket is a Querydsl query type for MyTicket
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMyTicket extends EntityPathBase<MyTicket> {
+
+    private static final long serialVersionUID = -949381696L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMyTicket myTicket = new QMyTicket("myTicket");
+
+    public final org.example.springplusteam.common.QBaseEntity _super = new org.example.springplusteam.common.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final org.example.springplusteam.domain.ticket.QTicket ticket;
+
+    public final org.example.springplusteam.domain.user.QUser user;
+
+    public QMyTicket(String variable) {
+        this(MyTicket.class, forVariable(variable), INITS);
+    }
+
+    public QMyTicket(Path<? extends MyTicket> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMyTicket(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMyTicket(PathMetadata metadata, PathInits inits) {
+        this(MyTicket.class, metadata, inits);
+    }
+
+    public QMyTicket(Class<? extends MyTicket> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.ticket = inits.isInitialized("ticket") ? new org.example.springplusteam.domain.ticket.QTicket(forProperty("ticket")) : null;
+        this.user = inits.isInitialized("user") ? new org.example.springplusteam.domain.user.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/org/example/springplusteam/domain/ticket/QTicket.java
+++ b/src/main/generated/org/example/springplusteam/domain/ticket/QTicket.java
@@ -19,7 +19,15 @@ public class QTicket extends EntityPathBase<Ticket> {
 
     public static final QTicket ticket = new QTicket("ticket");
 
+    public final org.example.springplusteam.common.QBaseEntity _super = new org.example.springplusteam.common.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
     public final NumberPath<Long> Id = createNumber("Id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
 
     public final StringPath name = createString("name");
 

--- a/src/main/generated/org/example/springplusteam/domain/ticket/QTicket.java
+++ b/src/main/generated/org/example/springplusteam/domain/ticket/QTicket.java
@@ -1,0 +1,45 @@
+package org.example.springplusteam.domain.ticket;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTicket is a Querydsl query type for Ticket
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTicket extends EntityPathBase<Ticket> {
+
+    private static final long serialVersionUID = -1431715392L;
+
+    public static final QTicket ticket = new QTicket("ticket");
+
+    public final NumberPath<Long> Id = createNumber("Id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public final NumberPath<Integer> price = createNumber("price", Integer.class);
+
+    public final NumberPath<Integer> quantity = createNumber("quantity", Integer.class);
+
+    public final NumberPath<Integer> useQuantity = createNumber("useQuantity", Integer.class);
+
+    public QTicket(String variable) {
+        super(Ticket.class, forVariable(variable));
+    }
+
+    public QTicket(Path<? extends Ticket> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTicket(PathMetadata metadata) {
+        super(Ticket.class, metadata);
+    }
+
+}
+

--- a/src/main/java/org/example/springplusteam/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/springplusteam/common/exception/ErrorCode.java
@@ -12,7 +12,10 @@ public enum ErrorCode {
     EXISTS_EMAIL(400, "존재하는 이메일 입니다."),
     PRODUCT_NOT_FOUND(404, "상품을 찾을 수 없습니다."),
     ORDER_NOT_FOUND(404, "해당 주문을 찾을 수 없습니다."),
-    ORDER_BAD_REQUEST(400, "잘못된 주문 상태 변경 요청입니다.");
+    ORDER_BAD_REQUEST(400, "잘못된 주문 상태 변경 요청입니다."),
+    TICKET_NOT_FOUND(404, "티켓을 찾을 수 없습니다."),
+    ;
+
 
     private final int status;
     private final String message;

--- a/src/main/java/org/example/springplusteam/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/springplusteam/common/exception/ErrorCode.java
@@ -14,6 +14,8 @@ public enum ErrorCode {
     ORDER_NOT_FOUND(404, "해당 주문을 찾을 수 없습니다."),
     ORDER_BAD_REQUEST(400, "잘못된 주문 상태 변경 요청입니다."),
     TICKET_NOT_FOUND(404, "티켓을 찾을 수 없습니다."),
+    NO_SEAT_AVAILABLE(400, "남아있는 좌석이 없습니다."),
+    ALREADY_RESERVE_SEAT(400, "이미 예약되어있는 좌석입니다."),
     ;
 
 

--- a/src/main/java/org/example/springplusteam/common/security/SecurityConfig.java
+++ b/src/main/java/org/example/springplusteam/common/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.example.springplusteam.common.security.filter.CustomAuthenticationFil
 import org.example.springplusteam.common.security.filter.CustomAuthorizationFilter;
 import org.example.springplusteam.common.security.filter.GlobalExceptionHandlerFilter;
 import org.example.springplusteam.common.security.jwt.JwtUtil;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -44,7 +46,7 @@ public class SecurityConfig {
                         .dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.ERROR).permitAll()
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers("/error").permitAll()
-                        .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers(PathRequest.toH2Console()).permitAll()
                         .anyRequest().authenticated())
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                 .csrf(AbstractHttpConfigurer::disable)
@@ -61,6 +63,8 @@ public class SecurityConfig {
         return http.build();
     }
 
+
+
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
@@ -71,5 +75,12 @@ public class SecurityConfig {
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
         provider.setUserDetailsService(authUserService);
         return provider;
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "spring.h2.console.enabled", havingValue = "true")
+    public WebSecurityCustomizer configureH2ConsoleEnable() {
+        return web -> web.ignoring()
+                .requestMatchers(PathRequest.toH2Console());
     }
 }

--- a/src/main/java/org/example/springplusteam/config/RedisConfig.java
+++ b/src/main/java/org/example/springplusteam/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package org.example.springplusteam.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/org/example/springplusteam/controller/TicketController.java
+++ b/src/main/java/org/example/springplusteam/controller/TicketController.java
@@ -1,11 +1,16 @@
 package org.example.springplusteam.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.springplusteam.common.security.AuthUser;
 import org.example.springplusteam.dto.ticket.req.TicketCreateReqDto;
+import org.example.springplusteam.dto.ticket.req.TicketReserveReqDto;
 import org.example.springplusteam.dto.ticket.resp.TicketCreateRespDto;
+import org.example.springplusteam.dto.ticket.resp.TicketReserveRespDto;
 import org.example.springplusteam.service.TicketService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,9 +21,20 @@ public class TicketController {
 
     private final TicketService ticketService;
 
-
     @PostMapping("/api/v1/tickets")
     public ResponseEntity<TicketCreateRespDto> saveTicket(@RequestBody TicketCreateReqDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(ticketService.addTicket(dto));
+    }
+
+    @PostMapping("/api/ticket/{ticketId}")
+    public ResponseEntity<TicketReserveRespDto> reserve(
+            @PathVariable Long ticketId,
+            @RequestBody TicketReserveReqDto dto,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        TicketReserveRespDto respDto
+                = ticketService.reserveTicket(ticketId, authUser.getId(), dto.getSeatNumber());
+
+        return ResponseEntity.status(HttpStatus.OK).body(respDto);
     }
 }

--- a/src/main/java/org/example/springplusteam/controller/TicketController.java
+++ b/src/main/java/org/example/springplusteam/controller/TicketController.java
@@ -1,0 +1,24 @@
+package org.example.springplusteam.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.springplusteam.dto.ticket.req.TicketCreateReqDto;
+import org.example.springplusteam.dto.ticket.resp.TicketCreateRespDto;
+import org.example.springplusteam.service.TicketService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TicketController {
+
+    private final TicketService ticketService;
+
+
+    @PostMapping("/api/v1/tickets")
+    public ResponseEntity<TicketCreateRespDto> saveTicket(@RequestBody TicketCreateReqDto dto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(ticketService.addTicket(dto));
+    }
+}

--- a/src/main/java/org/example/springplusteam/domain/myTicket/MyTicket.java
+++ b/src/main/java/org/example/springplusteam/domain/myTicket/MyTicket.java
@@ -1,0 +1,31 @@
+package org.example.springplusteam.domain.myTicket;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.springplusteam.common.BaseEntity;
+import org.example.springplusteam.domain.ticket.Ticket;
+import org.example.springplusteam.domain.user.User;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "my_tickets")
+public class MyTicket extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Ticket ticket;
+
+    public MyTicket(User user, Ticket ticket) {
+        this.user = user;
+        this.ticket = ticket;
+    }
+}

--- a/src/main/java/org/example/springplusteam/domain/myTicket/MyTicketRepository.java
+++ b/src/main/java/org/example/springplusteam/domain/myTicket/MyTicketRepository.java
@@ -1,0 +1,6 @@
+package org.example.springplusteam.domain.myTicket;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MyTicketRepository extends JpaRepository<MyTicket, Long> {
+}

--- a/src/main/java/org/example/springplusteam/domain/ticket/Ticket.java
+++ b/src/main/java/org/example/springplusteam/domain/ticket/Ticket.java
@@ -5,12 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.springplusteam.common.BaseEntity;
 
 @Entity
 @Getter
 @Table(name = "tickets")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Ticket {
+public class Ticket extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,5 +28,10 @@ public class Ticket {
         this.price = price;
         this.quantity = quantity;
         this.useQuantity = useQuantity;
+    }
+
+    public void updateQuantities(){
+        this.quantity -= 1;
+        this.useQuantity += 1;
     }
 }

--- a/src/main/java/org/example/springplusteam/domain/ticket/Ticket.java
+++ b/src/main/java/org/example/springplusteam/domain/ticket/Ticket.java
@@ -1,0 +1,31 @@
+package org.example.springplusteam.domain.ticket;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "tickets")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Ticket {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+    private String name;
+    private int price;
+    private int quantity;
+    private int useQuantity;
+
+    @Builder
+    public Ticket(Long id, String name, int price, int quantity, int useQuantity) {
+        Id = id;
+        this.name = name;
+        this.price = price;
+        this.quantity = quantity;
+        this.useQuantity = useQuantity;
+    }
+}

--- a/src/main/java/org/example/springplusteam/domain/ticket/TicketRepository.java
+++ b/src/main/java/org/example/springplusteam/domain/ticket/TicketRepository.java
@@ -1,6 +1,16 @@
 package org.example.springplusteam.domain.ticket;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select t from Ticket t where t.Id = :id")
+    Optional<Ticket> findTicketWithLock(@Param("id") Long id);
 }

--- a/src/main/java/org/example/springplusteam/domain/ticket/TicketRepository.java
+++ b/src/main/java/org/example/springplusteam/domain/ticket/TicketRepository.java
@@ -1,0 +1,6 @@
+package org.example.springplusteam.domain.ticket;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+}

--- a/src/main/java/org/example/springplusteam/dto/ticket/req/TicketCreateReqDto.java
+++ b/src/main/java/org/example/springplusteam/dto/ticket/req/TicketCreateReqDto.java
@@ -1,0 +1,22 @@
+package org.example.springplusteam.dto.ticket.req;
+
+
+import lombok.Getter;
+import org.example.springplusteam.domain.ticket.Ticket;
+
+@Getter
+public class TicketCreateReqDto {
+    private String name;
+    private int price;
+    private int quantity;
+    private int useQuantity;
+
+    public static Ticket from(TicketCreateReqDto dto) {
+        return Ticket.builder()
+                .name(dto.getName())
+                .price(dto.getPrice())
+                .quantity(dto.getQuantity())
+                .useQuantity(dto.getUseQuantity())
+                .build();
+    }
+}

--- a/src/main/java/org/example/springplusteam/dto/ticket/req/TicketReserveReqDto.java
+++ b/src/main/java/org/example/springplusteam/dto/ticket/req/TicketReserveReqDto.java
@@ -1,0 +1,8 @@
+package org.example.springplusteam.dto.ticket.req;
+
+import lombok.Getter;
+
+@Getter
+public class TicketReserveReqDto {
+    private String seatNumber;
+}

--- a/src/main/java/org/example/springplusteam/dto/ticket/resp/TicketCreateRespDto.java
+++ b/src/main/java/org/example/springplusteam/dto/ticket/resp/TicketCreateRespDto.java
@@ -1,0 +1,21 @@
+package org.example.springplusteam.dto.ticket.resp;
+
+import lombok.Getter;
+import org.example.springplusteam.domain.ticket.Ticket;
+
+@Getter
+public class TicketCreateRespDto {
+    private Long id;
+    private String name;
+    private int price;
+    private int quantity;
+    private int useQuantity;
+
+    public TicketCreateRespDto(Ticket ticket) {
+        this.id = ticket.getId();
+        this.name = ticket.getName();
+        this.price = ticket.getPrice();
+        this.quantity = ticket.getQuantity();
+        this.useQuantity = ticket.getUseQuantity();
+    }
+}

--- a/src/main/java/org/example/springplusteam/dto/ticket/resp/TicketReserveRespDto.java
+++ b/src/main/java/org/example/springplusteam/dto/ticket/resp/TicketReserveRespDto.java
@@ -1,0 +1,11 @@
+package org.example.springplusteam.dto.ticket.resp;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TicketReserveRespDto {
+    private Long userId;
+    private String seatNumber;
+}

--- a/src/main/java/org/example/springplusteam/service/TicketService.java
+++ b/src/main/java/org/example/springplusteam/service/TicketService.java
@@ -1,15 +1,20 @@
 package org.example.springplusteam.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.val;
 import org.example.springplusteam.common.exception.CustomApiException;
 import org.example.springplusteam.common.exception.ErrorCode;
+import org.example.springplusteam.domain.myTicket.MyTicket;
+import org.example.springplusteam.domain.myTicket.MyTicketRepository;
 import org.example.springplusteam.domain.ticket.Ticket;
 import org.example.springplusteam.domain.ticket.TicketRepository;
+import org.example.springplusteam.domain.user.User;
+import org.example.springplusteam.domain.user.UserRepository;
 import org.example.springplusteam.dto.ticket.req.TicketCreateReqDto;
 import org.example.springplusteam.dto.ticket.resp.TicketCreateRespDto;
+import org.example.springplusteam.dto.ticket.resp.TicketReserveRespDto;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +22,8 @@ public class TicketService {
 
     private final TicketRepository ticketRepository;
     private final RedisTemplate<String, String> redisTemplate;
+    private final UserRepository userRepository;
+    private final MyTicketRepository myTicketRepository;
 
     public TicketCreateRespDto addTicket(TicketCreateReqDto dto) {
         Ticket savedTicket = ticketRepository.save(TicketCreateReqDto.from(dto));
@@ -32,5 +39,34 @@ public class TicketService {
 
         redisTemplate.delete(key);
         redisTemplate.opsForValue().set(key + ":seatCount", String.valueOf(ticket.getQuantity()));
+    }
+
+    @Transactional
+    public TicketReserveRespDto reserveTicket(Long ticketId, Long userId, String seatNumber) {
+        String key = "ticket:seat:" + ticketId;
+
+        Ticket ticket = ticketRepository.findTicketWithLock(ticketId)
+                .orElseThrow(() -> new CustomApiException(ErrorCode.TICKET_NOT_FOUND));
+
+        if (ticket.getQuantity() <= 0) {
+            throw new CustomApiException(ErrorCode.NO_SEAT_AVAILABLE);
+        }
+
+        Long reserveSeat = redisTemplate.opsForSet().add(key, seatNumber);
+        if (reserveSeat != 1L) {
+            throw new CustomApiException(ErrorCode.ALREADY_RESERVE_SEAT);
+        }
+
+        Long decrement = redisTemplate.opsForValue().decrement(key + ":seatCount");
+        if (decrement < 0) {
+            throw new CustomApiException(ErrorCode.NO_SEAT_AVAILABLE);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorCode.USER_NOT_FOUND));
+        ticket.updateQuantities();
+        myTicketRepository.save(new MyTicket(user, ticket));
+        ticketRepository.save(ticket);
+        return new TicketReserveRespDto(user.getId(), seatNumber);
     }
 }

--- a/src/main/java/org/example/springplusteam/service/TicketService.java
+++ b/src/main/java/org/example/springplusteam/service/TicketService.java
@@ -1,0 +1,36 @@
+package org.example.springplusteam.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.example.springplusteam.common.exception.CustomApiException;
+import org.example.springplusteam.common.exception.ErrorCode;
+import org.example.springplusteam.domain.ticket.Ticket;
+import org.example.springplusteam.domain.ticket.TicketRepository;
+import org.example.springplusteam.dto.ticket.req.TicketCreateReqDto;
+import org.example.springplusteam.dto.ticket.resp.TicketCreateRespDto;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TicketService {
+
+    private final TicketRepository ticketRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public TicketCreateRespDto addTicket(TicketCreateReqDto dto) {
+        Ticket savedTicket = ticketRepository.save(TicketCreateReqDto.from(dto));
+        initializeTicket(savedTicket.getId());
+        return new TicketCreateRespDto(savedTicket);
+    }
+
+    private void initializeTicket(Long ticketId) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new CustomApiException(ErrorCode.TICKET_NOT_FOUND));
+
+        String key = "ticket:seat:" + ticketId;
+
+        redisTemplate.delete(key);
+        redisTemplate.opsForValue().set(key + ":seatCount", String.valueOf(ticket.getQuantity()));
+    }
+}


### PR DESCRIPTION
## 티켓 발급 기능 

### 시나리오 
- AuthenticationPrincipal, PathParivable, DTO 를 통해 ticketId, userId, seatNumber 를 서비스 계층으로 넘겨줍니다. 
- 티켓 발급 시 티켓 정보를 찾습니다.
- DB에서 티켓 유효 수량이 남아있는지 확인합니다.
- DB 락을 걸어줍니다.  
- Redis Set 을 통해 예약하려는 좌석이 이미 예약되어있는지 확인합니다. 
- Redis decr 명령어를 통해 수량을 감소 시킨 후 수량이 0 밑으로 떨어지지 않는지 한번 더 유효성 검사를 수행합니다.
- 유효성검사를 수행하였다면 수량을 감소시킵니다. 
- 수량을 감소시켰다면 사용수량을 증가시킵니다. 
- 모든 로직을 수행하였다면 DB 에 저장합니다.  

📌 `POST /api/v1/tickets/{ticketId}`

***RequestBody*** 
```json
{
  "seatNumber": "A1"
}
```

***ResponseBody*** 
```json
{
  "id": 1
}
```