### PR TITLE
[FEAT]쿠폰 발급 기능 구현

### DIFF
--- a/src/main/generated/org/example/springplusteam/domain/coupon/QCoupon.java
+++ b/src/main/generated/org/example/springplusteam/domain/coupon/QCoupon.java
@@ -19,7 +19,15 @@ public class QCoupon extends EntityPathBase<Coupon> {
 
     public static final QCoupon coupon = new QCoupon("coupon");
 
+    public final org.example.springplusteam.common.QBaseEntity _super = new org.example.springplusteam.common.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
     public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
 
     public final StringPath name = createString("name");
 

--- a/src/main/generated/org/example/springplusteam/domain/coupon/QCoupon.java
+++ b/src/main/generated/org/example/springplusteam/domain/coupon/QCoupon.java
@@ -37,6 +37,8 @@ public class QCoupon extends EntityPathBase<Coupon> {
 
     public final NumberPath<Integer> useQuantity = createNumber("useQuantity", Integer.class);
 
+    public final NumberPath<Integer> version = createNumber("version", Integer.class);
+
     public QCoupon(String variable) {
         super(Coupon.class, forVariable(variable));
     }

--- a/src/main/generated/org/example/springplusteam/domain/myCoupon/QMyCoupon.java
+++ b/src/main/generated/org/example/springplusteam/domain/myCoupon/QMyCoupon.java
@@ -1,0 +1,62 @@
+package org.example.springplusteam.domain.myCoupon;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMyCoupon is a Querydsl query type for MyCoupon
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMyCoupon extends EntityPathBase<MyCoupon> {
+
+    private static final long serialVersionUID = 21607168L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMyCoupon myCoupon = new QMyCoupon("myCoupon");
+
+    public final org.example.springplusteam.common.QBaseEntity _super = new org.example.springplusteam.common.QBaseEntity(this);
+
+    public final org.example.springplusteam.domain.coupon.QCoupon coupon;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final org.example.springplusteam.domain.user.QUser user;
+
+    public QMyCoupon(String variable) {
+        this(MyCoupon.class, forVariable(variable), INITS);
+    }
+
+    public QMyCoupon(Path<? extends MyCoupon> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMyCoupon(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMyCoupon(PathMetadata metadata, PathInits inits) {
+        this(MyCoupon.class, metadata, inits);
+    }
+
+    public QMyCoupon(Class<? extends MyCoupon> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.coupon = inits.isInitialized("coupon") ? new org.example.springplusteam.domain.coupon.QCoupon(forProperty("coupon")) : null;
+        this.user = inits.isInitialized("user") ? new org.example.springplusteam.domain.user.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/java/org/example/springplusteam/common/exception/ErrorCode.java
+++ b/src/main/java/org/example/springplusteam/common/exception/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     TICKET_NOT_FOUND(404, "티켓을 찾을 수 없습니다."),
     NO_SEAT_AVAILABLE(400, "남아있는 좌석이 없습니다."),
     ALREADY_RESERVE_SEAT(400, "이미 예약되어있는 좌석입니다."),
+    COUPON_NOT_FOUND(404, "쿠폰을 찾을 수 없습니다."),
+    NO_COUPON_AVAILABLE(400,"남아있는 쿠폰이 없습니다."),
     ;
 
 

--- a/src/main/java/org/example/springplusteam/controller/CouponController.java
+++ b/src/main/java/org/example/springplusteam/controller/CouponController.java
@@ -1,24 +1,35 @@
 package org.example.springplusteam.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.springplusteam.common.security.AuthUser;
 import org.example.springplusteam.dto.coupon.req.CouponCreateReqDto;
 import org.example.springplusteam.dto.coupon.resp.CouponCreateRespDto;
+import org.example.springplusteam.dto.coupon.resp.CouponReserveRespDto;
 import org.example.springplusteam.service.CouponService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 public class CouponController {
     private final CouponService couponService;
 
-    @PostMapping("/api/v1/coupones")
+    @PostMapping("/api/v1/coupons")
     public ResponseEntity<CouponCreateRespDto> createCoupon(@RequestBody CouponCreateReqDto reqDto
     ) {
         CouponCreateRespDto respDto = couponService.createCoupon(reqDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(respDto);
+    }
+
+    @PostMapping("/api/v1/coupons/{couponId}")
+    public ResponseEntity<CouponReserveRespDto> reserveCoupon(
+            @AuthenticationPrincipal AuthUser user,
+            @PathVariable Long couponId
+    ) {
+        Long userId = user.getId();
+        CouponReserveRespDto respDto = couponService.reserveCoupon(userId, couponId);
+        return ResponseEntity.status(HttpStatus.OK).body(respDto);
     }
 }

--- a/src/main/java/org/example/springplusteam/domain/coupon/Coupon.java
+++ b/src/main/java/org/example/springplusteam/domain/coupon/Coupon.java
@@ -20,13 +20,17 @@ public class Coupon extends BaseEntity {
     private int quantity;
     private int useQuantity;
 
+    @Version
+    private int version;
+
     @Builder
-    public Coupon(Long id, String name, int price, int quantity, int useQuantity) {
+    public Coupon(Long id, String name, int price, int quantity, int useQuantity, int version) {
         this.id = id;
         this.name = name;
         this.price = price;
         this.quantity = quantity;
         this.useQuantity = useQuantity;
+        this.version = version;
     }
 
     public void updateQuantities(){

--- a/src/main/java/org/example/springplusteam/domain/coupon/Coupon.java
+++ b/src/main/java/org/example/springplusteam/domain/coupon/Coupon.java
@@ -1,15 +1,17 @@
 package org.example.springplusteam.domain.coupon;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.springplusteam.common.BaseEntity;
 
 @Getter
 @Entity
-@Table(name = "copones")
-@NoArgsConstructor
-public class Coupon {
+@Table(name = "coupons")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -25,5 +27,10 @@ public class Coupon {
         this.price = price;
         this.quantity = quantity;
         this.useQuantity = useQuantity;
+    }
+
+    public void updateQuantities(){
+        this.quantity -= 1;
+        this.useQuantity += 1;
     }
 }

--- a/src/main/java/org/example/springplusteam/domain/myCoupon/MyCoupon.java
+++ b/src/main/java/org/example/springplusteam/domain/myCoupon/MyCoupon.java
@@ -1,0 +1,31 @@
+package org.example.springplusteam.domain.myCoupon;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.example.springplusteam.common.BaseEntity;
+import org.example.springplusteam.domain.coupon.Coupon;
+import org.example.springplusteam.domain.user.User;
+
+@Entity
+@Table(name = "my_coupons")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyCoupon extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id")
+    private Coupon coupon;
+
+    public MyCoupon(User user, Coupon coupon) {
+        this.user = user;
+        this.coupon = coupon;
+    }
+}

--- a/src/main/java/org/example/springplusteam/domain/myCoupon/MyCouponRepository.java
+++ b/src/main/java/org/example/springplusteam/domain/myCoupon/MyCouponRepository.java
@@ -1,0 +1,6 @@
+package org.example.springplusteam.domain.myCoupon;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MyCouponRepository extends JpaRepository<MyCoupon, Long> {
+}

--- a/src/main/java/org/example/springplusteam/dto/coupon/resp/CouponReserveRespDto.java
+++ b/src/main/java/org/example/springplusteam/dto/coupon/resp/CouponReserveRespDto.java
@@ -1,0 +1,14 @@
+package org.example.springplusteam.dto.coupon.resp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+@Builder
+@Getter
+public class CouponReserveRespDto {
+    private Long id;
+    private String name;
+    private int price;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/example/springplusteam/service/CouponService.java
+++ b/src/main/java/org/example/springplusteam/service/CouponService.java
@@ -1,10 +1,17 @@
 package org.example.springplusteam.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.springplusteam.common.exception.CustomApiException;
+import org.example.springplusteam.common.exception.ErrorCode;
 import org.example.springplusteam.domain.coupon.Coupon;
 import org.example.springplusteam.domain.coupon.CouponRepository;
+import org.example.springplusteam.domain.myCoupon.MyCoupon;
+import org.example.springplusteam.domain.myCoupon.MyCouponRepository;
+import org.example.springplusteam.domain.user.User;
+import org.example.springplusteam.domain.user.UserRepository;
 import org.example.springplusteam.dto.coupon.req.CouponCreateReqDto;
 import org.example.springplusteam.dto.coupon.resp.CouponCreateRespDto;
+import org.example.springplusteam.dto.coupon.resp.CouponReserveRespDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CouponService {
     private final CouponRepository couponRepository;
+    private final UserRepository userRepository;
+    private final MyCouponRepository myCouponRepository;
 
     @Transactional
     public CouponCreateRespDto createCoupon(CouponCreateReqDto reqDto) {
@@ -30,6 +39,35 @@ public class CouponService {
                 .price(coupon.getPrice())
                 .quantity(coupon.getQuantity())
                 .useQuantity(coupon.getUseQuantity())
+                .build();
+
+        return respDto;
+    }
+
+    public CouponReserveRespDto reserveCoupon(Long userId, Long couponId) {
+         User user = userRepository.findById(userId).orElseThrow(() ->
+                new CustomApiException(ErrorCode.USER_NOT_FOUND));
+
+         Coupon coupon = couponRepository.findById(couponId).orElseThrow(() ->
+                new CustomApiException(ErrorCode.COUPON_NOT_FOUND));
+
+        if (!(coupon.getQuantity() > 0)) {
+            throw new CustomApiException(ErrorCode.NO_COUPON_AVAILABLE);
+        }
+
+        coupon.updateQuantities();
+
+        MyCoupon myCoupon = new MyCoupon(user, coupon);
+
+        couponRepository.save(coupon);
+
+        myCouponRepository.save(myCoupon);
+
+        CouponReserveRespDto respDto = CouponReserveRespDto.builder()
+                .id(coupon.getId())
+                .name(coupon.getName())
+                .price(coupon.getPrice())
+                .createdAt(coupon.getModifiedAt())
                 .build();
 
         return respDto;

--- a/src/test/java/org/example/springplusteam/service/CouponServiceTest.java
+++ b/src/test/java/org/example/springplusteam/service/CouponServiceTest.java
@@ -1,42 +1,69 @@
 package org.example.springplusteam.service;
 
+import org.example.springplusteam.common.exception.CustomApiException;
+import org.example.springplusteam.common.exception.ErrorCode;
+import org.example.springplusteam.domain.coupon.Coupon;
+import org.example.springplusteam.domain.coupon.CouponRepository;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 @SpringBootTest
+@Transactional
 class CouponServiceTest {
-
 
     @Autowired
     private CouponService couponService;
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @BeforeEach
+    void setup() {
+        couponRepository.deleteAll(); // 기존 데이터 초기화
+    }
 
     @Test
-    @DisplayName("동시성 테스트")
-    void tsetCounterConcurrency() throws InterruptedException {
-        int numberOfThreads = 100;
+    @DisplayName("유저 1000명이 동시에 쿠폰 100개를 발급하려는 경우, 동시성이 발생하여 쿠폰 발급이 이뤄지지 않는다.")
+    void testCounterConcurrency() throws InterruptedException {
+        Coupon coupon = Coupon.builder()
+                .name("테스트 쿠폰")
+                .price(10000)
+                .quantity(100)
+                .useQuantity(0)
+                .build();
+
+        couponRepository.save(coupon);
+
+        int numberOfThreads = 1000;
+
         ExecutorService executorService = Executors.newFixedThreadPool(10);
         CountDownLatch doneSignal = new CountDownLatch(numberOfThreads);
 
         AtomicInteger successCount = new AtomicInteger();
         AtomicInteger failCount = new AtomicInteger();
+        AtomicLong userIdGenerator = new AtomicLong(1L);
 
         for (int i = 0; i < numberOfThreads; i++) {
             executorService.execute(() -> {
                 try {
-                    Long couponId = 1L;
-                    couponService.reserveCoupon(,couponId);
+                    couponService.reserveCoupon(userIdGenerator.getAndIncrement(), coupon.getId());
                     successCount.getAndIncrement();
+                } catch (ObjectOptimisticLockingFailureException e) {
+                    failCount.getAndIncrement(); // 낙관적 잠금 실패 시 카운트 증가
                 } catch (Exception e) {
                     failCount.getAndIncrement();
-                }  finally {
+                } finally {
                     doneSignal.countDown();
                 }
             });
@@ -45,12 +72,13 @@ class CouponServiceTest {
         doneSignal.await();
         executorService.shutdown();
 
-        Assertions.assertEquals(successCount.get(), couponService.);
+        Coupon findCoupon = couponRepository.findById(coupon.getId()).orElseThrow(() ->
+                new CustomApiException(ErrorCode.COUPON_NOT_FOUND));
 
+
+        Assertions.assertEquals(findCoupon.getUseQuantity(), successCount.get());
+
+        System.out.println("발급된 쿠폰 개수: " + findCoupon.getUseQuantity());
+        System.out.println("미급된 쿠폰 개수: " + findCoupon.getQuantity());
     }
-
-
-    @Test
-
-
 }

--- a/src/test/java/org/example/springplusteam/service/CouponServiceTest.java
+++ b/src/test/java/org/example/springplusteam/service/CouponServiceTest.java
@@ -1,0 +1,56 @@
+package org.example.springplusteam.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@SpringBootTest
+class CouponServiceTest {
+
+
+    @Autowired
+    private CouponService couponService;
+
+    @Test
+    @DisplayName("동시성 테스트")
+    void tsetCounterConcurrency() throws InterruptedException {
+        int numberOfThreads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch doneSignal = new CountDownLatch(numberOfThreads);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.execute(() -> {
+                try {
+                    Long couponId = 1L;
+                    couponService.reserveCoupon(,couponId);
+                    successCount.getAndIncrement();
+                } catch (Exception e) {
+                    failCount.getAndIncrement();
+                }  finally {
+                    doneSignal.countDown();
+                }
+            });
+        }
+
+        doneSignal.await();
+        executorService.shutdown();
+
+        Assertions.assertEquals(successCount.get(), couponService.);
+
+    }
+
+
+    @Test
+
+
+}


### PR DESCRIPTION
## 쿠폰 발급 기능 구현 

### 시나리오
* 생성된 쿠폰을 발급하면 updateQuantities메서드가 실행되어 총 수량이 1씩 감소하고 사용된 수량이 1씩 증가합니다.

📌 `POST /api/v1/coupones/{couponId}`

***ResponseBody*** 
```json
{
  "id": 1,
  "name" : "할인쿠폰",
  "price": 1000,
 "createdAt": "2024-11-27-11:00:00"
}
```