### PR TITLE
[FEAT] 상품 단건 조회 조회수 캐싱

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/example/springplusteam/SpringPlusTeamApplication.java
+++ b/src/main/java/org/example/springplusteam/SpringPlusTeamApplication.java
@@ -2,10 +2,12 @@ package org.example.springplusteam;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class SpringPlusTeamApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/example/springplusteam/config/CacheConfig.java
+++ b/src/main/java/org/example/springplusteam/config/CacheConfig.java
@@ -1,0 +1,32 @@
+package org.example.springplusteam.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheConfiguration redisCacheConfiguration() {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofSeconds(300))
+//                .disableCachingNullValues() // null 여부
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+                )
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
+                );
+    }
+
+
+
+}

--- a/src/main/java/org/example/springplusteam/controller/ProductV2Controller.java
+++ b/src/main/java/org/example/springplusteam/controller/ProductV2Controller.java
@@ -18,7 +18,7 @@ public class ProductV2Controller {
 
     @GetMapping("/api/v2/products/{productId}")
     public ResponseEntity<ProductRespDto> getProduct(@PathVariable Long productId, @AuthenticationPrincipal AuthUser authUser) {
-        ProductRespDto productRespDto = productService.getProductViewCount(productId, authUser.getId());
+        ProductRespDto productRespDto = productService.getProductWithViewCount(productId, authUser.getId());
         return ResponseEntity.ok(productRespDto);
     }
 

--- a/src/main/java/org/example/springplusteam/controller/ProductV2Controller.java
+++ b/src/main/java/org/example/springplusteam/controller/ProductV2Controller.java
@@ -1,0 +1,25 @@
+package org.example.springplusteam.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.springplusteam.common.security.AuthUser;
+import org.example.springplusteam.dto.product.resp.ProductRespDto;
+import org.example.springplusteam.service.ProductService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductV2Controller {
+
+    private final ProductService productService;
+
+    @GetMapping("/api/v2/products/{productId}")
+    public ResponseEntity<ProductRespDto> getProduct(@PathVariable Long productId, @AuthenticationPrincipal AuthUser authUser) {
+        ProductRespDto productRespDto = productService.getProductViewCount(productId, authUser.getId());
+        return ResponseEntity.ok(productRespDto);
+    }
+
+}

--- a/src/main/java/org/example/springplusteam/domain/view/View.java
+++ b/src/main/java/org/example/springplusteam/domain/view/View.java
@@ -1,0 +1,25 @@
+package org.example.springplusteam.domain.view;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.springplusteam.common.BaseEntity;
+
+@Entity
+@Getter
+@Table(name = "views")
+@NoArgsConstructor
+public class View extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private Long productId;
+
+    public View(Long productId, Long authUserId) {
+        this.userId = authUserId;
+        this.productId = productId;
+    }
+}

--- a/src/main/java/org/example/springplusteam/domain/view/ViewRepository.java
+++ b/src/main/java/org/example/springplusteam/domain/view/ViewRepository.java
@@ -1,0 +1,10 @@
+package org.example.springplusteam.domain.view;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ViewRepository extends JpaRepository<View, Long> {
+
+    int countByProductId(Long productId);
+
+    boolean existsByProductIdAndUserId(Long id, Long authUserId);
+}

--- a/src/main/java/org/example/springplusteam/dto/product/resp/ProductRespDto.java
+++ b/src/main/java/org/example/springplusteam/dto/product/resp/ProductRespDto.java
@@ -1,0 +1,29 @@
+package org.example.springplusteam.dto.product.resp;
+
+import lombok.Getter;
+import org.example.springplusteam.domain.product.Product;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ProductRespDto {
+
+    private Long id;
+    private String name;
+    private int price;
+    private String performance_time;
+    private LocalDateTime performance_period;
+    private int count;
+
+
+    public ProductRespDto(Product product, int count) {
+        this.id = product.getId();
+        this.name = product.getName();
+        this.price = product.getPrice();
+        this.performance_time = product.getPerformance_time();
+        this.performance_period = product.getPerformance_period();
+        this.count = count;
+    }
+
+
+}

--- a/src/main/java/org/example/springplusteam/service/ProductService.java
+++ b/src/main/java/org/example/springplusteam/service/ProductService.java
@@ -1,8 +1,6 @@
 package org.example.springplusteam.service;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+import lombok.RequiredArgsConstructor;
 import org.example.springplusteam.common.exception.CustomApiException;
 import org.example.springplusteam.common.exception.ErrorCode;
 import org.example.springplusteam.domain.product.Product;
@@ -17,7 +15,8 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +24,7 @@ public class ProductService {
 
 	private final ProductRepository productRepository;
 	private final ViewRepository viewRepository;
+	private final ViewService viewService;
 
 	public ProductCreateRespDto createProduct(ProductCreateReqDto reqDto) {
 		Product product = Product.builder()
@@ -62,15 +62,14 @@ public class ProductService {
 		return new PageImpl<>(content, pageable, total);
 	}
 
-	public ProductRespDto getProductViewCount(Long productId, Long authUserId) {
+	public ProductRespDto getProductWithViewCount(Long productId, Long authUserId) {
 		Product product = productRepository.findById(productId)
 				.orElseThrow(()-> new CustomApiException(ErrorCode.PRODUCT_NOT_FOUND));
 
 		saveViewLog(authUserId, product.getId());
 
-		// 이력테이블에서 product.id로 count 쿼리로 조회수 카운트한다.
-		int count = viewRepository.countByProductId(product.getId());
-        return new ProductRespDto(product, count);
+		int viewCount = viewService.getViewCount(product.getId());
+		return new ProductRespDto(product, viewCount);
 	}
 
 	private void saveViewLog(Long authUserId, Long productId) {

--- a/src/main/java/org/example/springplusteam/service/ProductService.java
+++ b/src/main/java/org/example/springplusteam/service/ProductService.java
@@ -74,9 +74,18 @@ public class ProductService {
 	}
 
 	private void saveViewLog(Long authUserId, Long productId) {
+		// 존재한다면? 다음 로직 타면 안돼
+		if (hasUserViewedProduct(authUserId, productId)){
+			return;
+		}
 		// 조회한 product.id와 로그인한 유저를 조회 이력에 남김
 		View view = new View(productId, authUserId);
 		// 조회 이력 저장
 		viewRepository.save(view);
+	}
+
+	private boolean hasUserViewedProduct(Long authUserId, Long productId) {
+		// 동일 유저가 조회 했을때 이력이 쌓이지 않아야함
+		return viewRepository.existsByProductIdAndUserId(productId, authUserId);
 	}
 }

--- a/src/main/java/org/example/springplusteam/service/ViewService.java
+++ b/src/main/java/org/example/springplusteam/service/ViewService.java
@@ -1,0 +1,20 @@
+package org.example.springplusteam.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.springplusteam.domain.view.ViewRepository;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ViewService {
+
+    private final ViewRepository viewRepository;
+
+    @Cacheable(value = "ViewCount", key = "#productId")
+    public int getViewCount(Long productId) {
+        // 이력테이블에서 product.id로 count 쿼리로 조회수 카운트한다.
+        return viewRepository.countByProductId(productId);
+    }
+
+}


### PR DESCRIPTION
***상품 단건조회 조회수 캐싱***

📌` GET  api/v2/products/{productId}` 

기존 ProductController에서 ProductV2Controller 생성

상품 조회 시 해당 상품의 조회수를 카운팅합니다.
동일한 유저가 조회수를 무제한적으로 올리는 것을 방지합니다.
상품을 캐시에 저장하여 응답 속도를 높이고 시스템 부하를 줄입니다.

 Redis 캐시 활용

ReseponseBody
```json
   {
  "id": 1,
  "name": "알라딘",
  "price" : 10000,
  "performanceTime": "150분", 
  "performancePeriod": "2024-12-25",
  "count": 6
   }
```